### PR TITLE
fix: fixing some inconsistencies between classes

### DIFF
--- a/src/test/java/AlphaNumericFieldErrorTest.java
+++ b/src/test/java/AlphaNumericFieldErrorTest.java
@@ -14,7 +14,7 @@ public class AlphaNumericFieldErrorTest extends WebDriverSettings {
         driver.findElement(By.xpath(TestSelectors.MALERADIOBUTTONXPATH)).click();
         driver.findElement(By.xpath(TestSelectors.CALCULATEBUTTONXPATH)).click();
         // Then
-        String result = driver.findElement(By.cssSelector(TestSelectors.ERRORMESSAGECSS)).getText();
+        String result = driver.findElement(By.xpath(TestSelectors.ERRORMESSAGEXPATH)).getText();
         System.out.println(result);
         Assert.assertEquals("Рост должен быть в диапазоне 50-300 см.", result);
     }
@@ -29,7 +29,7 @@ public class AlphaNumericFieldErrorTest extends WebDriverSettings {
         driver.findElement(By.xpath(TestSelectors.MALERADIOBUTTONXPATH)).click();
         driver.findElement(By.xpath(TestSelectors.CALCULATEBUTTONXPATH)).click();
         // Then
-        String result = driver.findElement(By.cssSelector(TestSelectors.ERRORMESSAGECSS)).getText();
+        String result = driver.findElement(By.xpath(TestSelectors.ERRORMESSAGEXPATH)).getText();
         System.out.println(result);
         Assert.assertEquals("Вес должен быть в диапазоне 3-500 кг.", result);
     }

--- a/src/test/java/InvalidValueTest.java
+++ b/src/test/java/InvalidValueTest.java
@@ -16,7 +16,7 @@ public class InvalidValueTest extends WebDriverSettings {
         Thread.sleep(1000);
         WebElement searchBtn2 = driver.findElement(By.xpath(TestSelectors.CALCULATEBUTTONXPATH));
         searchBtn2.click();
-        String actualMessage = driver.findElement(By.xpath(TestSelectors.ERRORMESSAGECSS)).getText();
+        String actualMessage = driver.findElement(By.xpath(TestSelectors.ERRORMESSAGEXPATH)).getText();
         Assert.assertEquals("Не указано имя.\nРост должен быть в диапазоне 50-300 см." +
                 "\nВес должен быть в диапазоне 3-500 кг.\nНе указан пол.", actualMessage);
 
@@ -30,7 +30,7 @@ public class InvalidValueTest extends WebDriverSettings {
         driver.findElement(By.xpath(TestSelectors.WEIGHTXPATH)).sendKeys("500.01");
         Thread.sleep(1000);
         driver.findElement(By.xpath(TestSelectors.CALCULATEBUTTONXPATH)).click();
-        String actualMessage = driver.findElement(By.xpath(TestSelectors.ERRORMESSAGECSS)).getText();
+        String actualMessage = driver.findElement(By.xpath(TestSelectors.ERRORMESSAGEXPATH)).getText();
         Assert.assertEquals("Не указано имя.\nРост должен быть в диапазоне 50-300 см." +
                 "\nВес должен быть в диапазоне 3-500 кг.\nНе указан пол.", actualMessage);
     }
@@ -40,7 +40,7 @@ public class InvalidValueTest extends WebDriverSettings {
         driver.get(TestSelectors.WEBSITEURL);
         Thread.sleep(1000);
         driver.findElement(By.xpath(TestSelectors.CALCULATEBUTTONXPATH)).click();
-        String actualMessage = driver.findElement(By.xpath(TestSelectors.ERRORMESSAGECSS)).getText();
+        String actualMessage = driver.findElement(By.xpath(TestSelectors.ERRORMESSAGEXPATH)).getText();
         Assert.assertEquals("Не указано имя.\nРост должен быть в диапазоне 50-300 см." +
                 "\nВес должен быть в диапазоне 3-500 кг.\nНе указан пол.", actualMessage);
     }

--- a/src/test/java/TestSelectors.java
+++ b/src/test/java/TestSelectors.java
@@ -6,6 +6,7 @@
         public static final String MALERADIOBUTTONXPATH = "//input[@value='m']";
         public static final String FEMALERADIOBUTTONXPATH = "//input[@value='f']";
         public static final String CALCULATEBUTTONXPATH = "//input[@value= 'Рассчитать']";
-        public static final String ERRORMESSAGECSS = "//b";
+        public static final String ERRORMESSAGEXPATH = "//b";
+        public static final String SUCCESSMESSAGEXPATH = "//td[2]";
     }
 

--- a/src/test/java/ValidValueTest.java
+++ b/src/test/java/ValidValueTest.java
@@ -14,9 +14,9 @@ public class ValidValueTest extends WebDriverSettings {
         driver.findElement(By.xpath(TestSelectors.MALERADIOBUTTONXPATH)).click();
         driver.findElement(By.xpath(TestSelectors.CALCULATEBUTTONXPATH)).click();
         // Then
-        String result = driver.findElement(By.cssSelector(TestSelectors.ERRORMESSAGECSS)).getText();
+        String result = driver.findElement(By.xpath(TestSelectors.SUCCESSMESSAGEXPATH)).getText();
         System.out.println(result);
-        Assert.assertEquals("Слишком малая масса тела.", result);
+        Assert.assertEquals("Слишком малая масса тела", result);
     }
     @Test
     public void testValidMaxValue() {
@@ -29,9 +29,9 @@ public class ValidValueTest extends WebDriverSettings {
         driver.findElement(By.xpath(TestSelectors.MALERADIOBUTTONXPATH)).click();
         driver.findElement(By.xpath(TestSelectors.CALCULATEBUTTONXPATH)).click();
         // Then
-        String result = driver.findElement(By.cssSelector(TestSelectors.ERRORMESSAGECSS)).getText();
+        String result = driver.findElement(By.xpath(TestSelectors.SUCCESSMESSAGEXPATH)).getText();
         System.out.println(result);
-        Assert.assertEquals("Значительный избыток массы тела, тучность.", result);
+        Assert.assertEquals("Значительный избыток массы тела, тучность", result);
     }
 
 }


### PR DESCRIPTION
fixed some issues with:
- searching by cssSelector instead of xpath in AlphaNumericFieldErrorTest.java
- refactored ERRORMESSAGECSS to ERRORMESSAGEXPATH in TestSelectors.java to avoid confusion since it is not a cssSelector type
- adding SUCCESSMESSAGEXPATH variable to TestSelectors.java which is needed for verifying Valid tests
- edited findElement locator for Success message in ValidValueTest.java (it was searching for Error message instead)
- also edited Expected message for ValidValueTest.java (they had extra "." symbol)
